### PR TITLE
Exclude cwh-0.298.zip from gradle clean task

### DIFF
--- a/host/build.gradle
+++ b/host/build.gradle
@@ -239,7 +239,7 @@ test {
 clean.doFirst {
   // Additions to the built-in clean
   delete "srcbin", "testbin", "cwh.log"
-  delete fileTree(dir: '.', include: '*.zip')
+  delete fileTree(dir: '.', include: '*.zip', exclude: 'cwh-0.298.zip')
 }
 
 // PROJECT POST-SETUP SCRIPT


### PR DESCRIPTION
cwh-0.298.zip is our special backwards compatibility zip to bridge users of the old start.sh to the new start.sh. This file should stay unchanged in the repo forever to bring old systems to the new way.

This PR closes area515#216 and prevents a `./gradlew clean` from deleting this file.

Users should still be careful not to commit and deletions of `cwh-0.298.zip`.
